### PR TITLE
Add z4h-tmux and z4h-ncurses formulae. To be used with zsh4humans only.

### DIFF
--- a/Formula/z4h-ncurses.rb
+++ b/Formula/z4h-ncurses.rb
@@ -1,0 +1,56 @@
+class Z4hNcurses < Formula
+  desc "Text-based UI library"
+  homepage "https://invisible-island.net/ncurses/announce.html"
+  url "https://ftp.gnu.org/gnu/ncurses/ncurses-6.5.tar.gz"
+  mirror "https://invisible-mirror.net/archives/ncurses/ncurses-6.5.tar.gz"
+  mirror "ftp://ftp.invisible-island.net/ncurses/ncurses-6.5.tar.gz"
+  mirror "https://ftpmirror.gnu.org/ncurses/ncurses-6.5.tar.gz"
+  sha256 "136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6"
+  license "MIT"
+
+  keg_only :provided_by_macos
+
+  depends_on "pkgconf" => :build
+
+  on_linux do
+    depends_on "gpatch" => :build
+  end
+
+  def install
+    args = [
+      "--prefix=#{prefix}",
+      "--disable-pc-files",
+      "--disable-mixed-case",
+      "--disable-rpath",
+      "--disable-bsdpad",
+      "--disable-termcap",
+      "--disable-rpath-hack",
+      "--enable-root-environ",
+      "--without-manpages",
+      "--without-tack",
+      "--without-tests",
+      "--without-pc-suffix",
+      "--without-pkg-config-libdir",
+      "--without-debug",
+      "--without-dlsym",
+      "--without-pcre2",
+      "--enable-sigwinch",
+      "--enable-widec",
+      "--without-shared",
+      "--without-cxx-shared",
+      "--with-gpm=no",
+      "--without-ada",
+    ]
+    args << "--with-terminfo-dirs=#{share}/terminfo:/etc/terminfo:/lib/terminfo:/usr/share/terminfo" if OS.linux?
+
+    system "./configure", *args
+    system "make", "install"
+
+    # Avoid hardcoding Cellar paths in client software.
+    inreplace bin/"ncursesw6-config", prefix, opt_prefix
+  end
+
+  test do
+    system "echo", "Done!"
+  end
+end

--- a/Formula/z4h-tmux.rb
+++ b/Formula/z4h-tmux.rb
@@ -1,0 +1,67 @@
+class Z4hTmux < Formula
+  desc "Terminal multiplexer"
+  homepage "https://tmux.github.io/"
+  url "https://github.com/tmux/tmux/releases/download/3.5a/tmux-3.5a.tar.gz"
+  sha256 "16216bd0877170dfcc64157085ba9013610b12b082548c7c9542cc0103198951"
+  license "ISC"
+
+  livecheck do
+    url :stable
+    regex(/v?(\d+(?:\.\d+)+[a-z]?)/i)
+    strategy :github_latest
+  end
+
+  keg_only :provided_by_macos
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkgconf" => :build
+  depends_on "libevent"
+  depends_on "z4h-ncurses"
+
+  uses_from_macos "bison" => :build # for yacc
+
+  # Old versions of macOS libc disagree with utf8proc character widths.
+  # https://github.com/tmux/tmux/issues/2223
+  on_system :linux, macos: :sierra_or_newer do
+    depends_on "utf8proc"
+  end
+
+  def install
+    system "sh", "autogen.sh" if build.head?
+
+    args = %W[
+      --enable-sixel
+      --sysconfdir=#{etc}
+    ]
+
+    # tmux finds the `tmux-256color` terminfo provided by our ncurses
+    # and uses that as the default `TERM`, but this causes issues for
+    # tools that link with the very old ncurses provided by macOS.
+    # https://github.com/Homebrew/homebrew-core/issues/102748
+    args << "--with-TERM=screen-256color" if OS.mac? && MacOS.version < :sonoma
+    args << "--enable-utf8proc" if OS.linux? || MacOS.version >= :high_sierra
+
+    ENV.append "LDFLAGS", "-lresolv"
+    system "./configure", *args, *std_configure_args
+
+    system "make", "install"
+
+    # pkgshare.install "example_tmux.conf"
+  end
+
+  test do
+    system bin/"tmux", "-V"
+
+    require "pty"
+
+    socket = testpath/tap.user
+    PTY.spawn bin/"tmux", "-S", socket, "-f", File::NULL
+    sleep 10
+
+    assert_path_exists socket
+    assert_predicate socket, :socket?
+    assert_equal "no server running on #{socket}", shell_output("#{bin}/tmux -S#{socket} list-sessions 2>&1", 1).chomp
+  end
+end

--- a/Formula/z4h-tmux.rb
+++ b/Formula/z4h-tmux.rb
@@ -1,8 +1,8 @@
 class Z4hTmux < Formula
   desc "Terminal multiplexer"
   homepage "https://tmux.github.io/"
-  url "https://github.com/tmux/tmux/releases/download/3.5a/tmux-3.5a.tar.gz"
-  sha256 "16216bd0877170dfcc64157085ba9013610b12b082548c7c9542cc0103198951"
+  url "http://10.0.0.5/AG/-/packages/generic/tmux/3.5a/files/1"
+  sha256 "c362793d319269793a1bd862a65674002db6baef523a5376c2d00517de824555"
   license "ISC"
 
   livecheck do


### PR DESCRIPTION
### Pull Request Description

This pull request introduces two new formulae: `z4h-tmux` and `z4h-ncurses`. formulae are specifically designed to be used with the `zsh4humans` framework, enhancing the user experience for those utilizing this shell environment.

**Changes Made:**
- Added the `z4h-tmux` formula, which integrates tmux functionality tailored for zsh4humans.
- Added the `z4h-ncurses` formula, providing ncurses support optimized for zsh4humans.

These additions aim to streamline the setup and usage of tmux and ncurses within the zsh4humans ecosystem, making it easier for users to leverage these tools effectively. 