### PR TITLE
feat: update Forgejo build, service, and bump rcloneUpdate Forgejo formula to describe the package, install the

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -36,9 +36,9 @@ class Curl < Formula
   keg_only :provided_by_macos
 
   depends_on "cmake" => :build
+  depends_on "pkgconf" => [:build, :test]
   depends_on "rust" => :build
 
-  depends_on "pkgconf" => [:build, :test]
   depends_on "brotli"
   depends_on "libnghttp2"
   depends_on "libssh2"

--- a/Formula/forgejo.rb
+++ b/Formula/forgejo.rb
@@ -1,5 +1,5 @@
 class Forgejo < Formula
-  desc "Painless self-hosted all-in-one software development service"
+  desc "Self-hosted lightweight software forge"
   homepage "https://forgejo.org/"
   url "https://codeberg.org/forgejo/forgejo/releases/download/v12.0.1/forgejo-src-12.0.1.tar.gz"
   sha256 "792f0435e9e4620da96a92305ed752f54b47ebc23d5f8e08a70299bac2245dd9"
@@ -11,23 +11,20 @@ class Forgejo < Formula
 
   uses_from_macos "sqlite"
 
-  conflicts_with "gitea", because: "both install `gitea` binaries"
-
   def install
     ENV["CGO_ENABLED"] = "1"
     ENV["TAGS"] = "bindata timetzdata sqlite sqlite_unlock_notify"
     system "make", "build"
     system "go", "build", "contrib/environment-to-ini/environment-to-ini.go"
-    bin.install "gitea"
+    bin.install "gitea" => "forgejo"
     bin.install "environment-to-ini"
-    bin.install_symlink "gitea" => "forgejo"
   end
 
   service do
     run [opt_bin/"forgejo", "web", "--work-path", var/"forgejo"]
     keep_alive true
-    log_path "/tmp/forgejo.out.log"
-    error_log_path "/tmp/forgejo.err.log"
+    log_path var/"log/forgejo.log"
+    error_log_path var/"log/forgejo.log"
   end
 
   test do

--- a/Formula/rclone.rb
+++ b/Formula/rclone.rb
@@ -1,8 +1,8 @@
 class Rclone < Formula
   desc "Rsync for cloud storage"
   homepage "https://rclone.org/"
-  url "https://github.com/rclone/rclone/archive/refs/tags/v1.70.3.tar.gz"
-  sha256 "0b25fb9f0cb26883cfa885576ddb34276564a1e224edc5aacab826f9ba22179d"
+  url "https://github.com/rclone/rclone/archive/refs/tags/v1.71.0.tar.gz"
+  sha256 "20eab33e279e7c14a20174db43277de3f5bbdcd248103e014d6e54374b43224a"
   license "MIT"
   head "https://github.com/rclone/rclone.git", branch: "master"
 


### PR DESCRIPTION
binary as forgejo, and redirect runtime logs to var/log instead of /tmp.

- Change description to "Self-hosted lightweight software forge" to
  reflect concise package intent.
- Remove conflicting explicit conflicts_with "gitea" entry and the
  redundant symlink install.

Bump rclone from v1.70.3 to v1.71.0.

- Update rclone source URL and sha256 to the new release.