### PR TITLE
feat: update versions for parsec-startup, forgejo, rsyncui

### DIFF
--- a/Casks/parsec-startup.rb
+++ b/Casks/parsec-startup.rb
@@ -1,5 +1,5 @@
 cask "parsec-startup" do
-  version "150-99"
+  version "150-100e"
   sha256 :no_check
 
   url "https://builds.parsecgaming.com/package/parsec-macos-startup.pkg",

--- a/Casks/rsyncui.rb
+++ b/Casks/rsyncui.rb
@@ -1,6 +1,6 @@
 cask "rsyncui" do
-  version "2.6.5"
-  sha256 "4d98075ea356969c8ddb578be34dabde31a99d7a8342fef5f20b23794b64a547"
+  version "2.6.6"
+  sha256 "7e44594651e6dfce69c00612e8051921114d111def9d792d72884eac4483714d"
 
   url "https://github.com/rsyncOSX/RsyncUI/releases/download/v#{version}/RsyncUI.#{version}.dmg"
   name "RsyncUI"

--- a/Formula/forgejo.rb
+++ b/Formula/forgejo.rb
@@ -1,8 +1,8 @@
 class Forgejo < Formula
   desc "Self-hosted lightweight software forge"
   homepage "https://forgejo.org/"
-  url "https://codeberg.org/forgejo/forgejo/releases/download/v12.0.1/forgejo-src-12.0.1.tar.gz"
-  sha256 "792f0435e9e4620da96a92305ed752f54b47ebc23d5f8e08a70299bac2245dd9"
+  url "https://codeberg.org/forgejo/forgejo/releases/download/v12.0.3/forgejo-src-12.0.3.tar.gz"
+  sha256 "65318cf8c843d92ee984f26072846df97a76f2c7f5dcb76746161c7d21b70974"
   license "GPL-3.0-or-later"
   head "https://codeberg.org/forgejo/forgejo.git", branch: "forgejo"
 


### PR DESCRIPTION
Bump Parsec startup cask to 150-100e to track the latest macOS
package build.

Upgrade Forgejo from 12.0.1 to 12.0.3 and update its source tarball
SHA256 to match the new release, ensuring formula installs the
correct upstream release.

Advance RsyncUI cask from 2.6.5 to 2.6.6 and update its SHA256 so the
cask downloads verify against the new release artifact.