### PR TITLE
chore(curl): bump to 8.16.0

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -13,11 +13,11 @@ class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server with HTTP/3 support using quiche"
   homepage "https://curl.se"
   # Don't forget to update both instances of the version in the GitHub mirror URL.
-  url "https://curl.se/download/curl-8.15.0.tar.bz2"
-  mirror "https://github.com/curl/curl/releases/download/curl-8_15_0/curl-8.15.0.tar.bz2"
-  mirror "http://fresh-center.net/linux/www/curl-8.15.0.tar.bz2"
-  mirror "http://fresh-center.net/linux/www/legacy/curl-8.15.0.tar.bz2"
-  sha256 "699a6d2192322792c88088576cff5fe188452e6ea71e82ca74409f07ecc62563"
+  url "https://curl.se/download/curl-8.16.0.tar.bz2"
+  mirror "https://github.com/curl/curl/releases/download/curl-8_16_0/curl-8.16.0.tar.bz2"
+  mirror "http://fresh-center.net/linux/www/curl-8.16.0.tar.bz2"
+  mirror "http://fresh-center.net/linux/www/legacy/curl-8.16.0.tar.bz2"
+  sha256 "9459180ab4933b30d0778ddd71c91fe2911fab731c46e59b3f4c8385b1596c91"
   license "curl"
 
   livecheck do


### PR DESCRIPTION
Update curl formula to 8.16.0.  Replace the download URL, GitHub
mirror and fresh-center mirrors to point at the new 8.16.0 release
and update the corresponding SHA256 checksum.