### PR TITLE
feat(cask): add munkiadmin-beta cask for v1.10.0b6

### DIFF
--- a/Casks/munkiadmin-beta.rb
+++ b/Casks/munkiadmin-beta.rb
@@ -1,0 +1,24 @@
+cask "munkiadmin-beta" do
+  version "1.10.0b6"
+  sha256 "63b709338473551119424b55058e989b198ae72efb42d7fcd001cdb7c4152411"
+
+  url "https://github.com/hjuutilainen/munkiadmin/releases/download/v#{version}/MunkiAdmin-#{version}.dmg",
+      verified: "github.com/hjuutilainen/munkiadmin/"
+  name "MunkiAdmin"
+  desc "Tool to manage Munki repositories"
+  homepage "https://hjuutilainen.github.io/munkiadmin/"
+
+  livecheck do
+    url :url
+    regex(/^v?(\d+(?:\.\d+)*)$/i)
+  end
+
+  app "MunkiAdmin.app"
+
+  zap trash: [
+    "~/Library/Application Support/MunkiAdmin",
+    "~/Library/Caches/com.hjuutilainen.MunkiAdmin",
+    "~/Library/Logs/MunkiAdmin",
+    "~/Library/Preferences/com.hjuutilainen.MunkiAdmin.plist",
+  ]
+end


### PR DESCRIPTION
Add a new Homebrew Cask for MunkiAdmin beta (version 1.10.0b6).