### PR TITLE
chore(forgejo): bump to v12.0.4

### DIFF
--- a/Formula/forgejo.rb
+++ b/Formula/forgejo.rb
@@ -1,8 +1,8 @@
 class Forgejo < Formula
   desc "Self-hosted lightweight software forge"
   homepage "https://forgejo.org/"
-  url "https://codeberg.org/forgejo/forgejo/releases/download/v12.0.3/forgejo-src-12.0.3.tar.gz"
-  sha256 "65318cf8c843d92ee984f26072846df97a76f2c7f5dcb76746161c7d21b70974"
+  url "https://codeberg.org/forgejo/forgejo/releases/download/v12.0.4/forgejo-src-12.0.4.tar.gz"
+  sha256 "b1adeec3f5f446c63996250a334be62baf0cd8fbb9ad71a3316a5896cb327d08"
   license "GPL-3.0-or-later"
   head "https://codeberg.org/forgejo/forgejo.git", branch: "forgejo"
 


### PR DESCRIPTION
Update Forgejo source URL and checksum to v12.0.4. This upgrades the
packaged release from v12.0.3 to v12.0.4, ensuring users install the
latest bug fixes and improvements from the upstream project. Adjust the
SHA256 to match the new tarball.