### PR TITLE
fix(cask): mark parsec-startup as auto-updating

### DIFF
--- a/Casks/parsec-startup.rb
+++ b/Casks/parsec-startup.rb
@@ -16,6 +16,7 @@ cask "parsec-startup" do
     end
   end
 
+  auto_updates true
   conflicts_with cask: "parsec"
 
   pkg "parsec-macos-startup.pkg"


### PR DESCRIPTION
Enable auto_updates for the parsec-startup cask to indicate the
startup helper can update itself independently of Homebrew Cask.
This avoids unnecessary upgrades being suggested by brew when the
helper is updated by the upstream installer, and keeps cask
metadata accurate.